### PR TITLE
Zusätzlicher Footer aus Seiteninhalt

### DIFF
--- a/LoopTemplate.php
+++ b/LoopTemplate.php
@@ -1018,12 +1018,14 @@ class LoopTemplate extends BaseTemplate {
 		if ( $this->loopSettings->extraFooter == "useExtraFooter" ) {
 			$html .= '<div class="col-12 text-center" id="extra-footer">
 					<div id="extra-footer-content" class="p-3">';
-			$extraFooterTitle = Title::newFromText( "MediaWiki:ExtraFooter" );
-			$extraFooterWikiPage = new WikiPage( $extraFooterTitle );
-			$parserOptions = $extraFooterWikiPage->makeParserOptions( $this->getSkin()->getContext() );
-			if ( $extraFooterWikiPage->getParserOutput( $parserOptions ) ) {
-				$html .= $extraFooterWikiPage->getParserOutput( $parserOptions )->mText; 
-			}
+			
+			$article = Article::newFromTitle( $this->title, $this->getSkin()->getContext() );
+			$localParser = new Parser();
+			$tmpTitle = Title::newFromText( 'NO TITLE' );
+			$parserOutput = $localParser->parse( "{{MediaWiki:ExtraFooter}}", $tmpTitle, new ParserOptions() );
+
+			$html .= $parserOutput->mText;
+			
 			$html .=  '</div></div>';
 		}
 		$html .= '<div class="container-fluid">

--- a/LoopTemplate.php
+++ b/LoopTemplate.php
@@ -1015,10 +1015,14 @@ class LoopTemplate extends BaseTemplate {
 		
 		$html = ""; 
 		
-		if ( $this->loopSettings->extraFooter == "useExtraFooter" && ! empty( $this->loopSettings->extraFooterParsed ) ) {
+		if ( $this->loopSettings->extraFooter == "useExtraFooter" ) {
 			$html .= '<div class="col-12 text-center" id="extra-footer">
-					<div id="extra-footer-content" class="p-3">' . 
-						$this->loopSettings->extraFooterParsed . '</div></div>';
+					<div id="extra-footer-content" class="p-3">';
+			$extraFooterTitle = Title::newFromText( "MediaWiki:ExtraFooter" );
+			$extraFooterWikiPage = new WikiPage( $extraFooterTitle );
+			$parserOptions = $extraFooterWikiPage->makeParserOptions( $this->getSkin()->getContext() );
+			$html .= $extraFooterWikiPage->getParserOutput( $parserOptions )->mText; 
+			$html .=  '</div></div>';
 		}
 		$html .= '<div class="container-fluid">
 		<div class="row">

--- a/LoopTemplate.php
+++ b/LoopTemplate.php
@@ -1021,7 +1021,9 @@ class LoopTemplate extends BaseTemplate {
 			$extraFooterTitle = Title::newFromText( "MediaWiki:ExtraFooter" );
 			$extraFooterWikiPage = new WikiPage( $extraFooterTitle );
 			$parserOptions = $extraFooterWikiPage->makeParserOptions( $this->getSkin()->getContext() );
-			$html .= $extraFooterWikiPage->getParserOutput( $parserOptions )->mText; 
+			if ( $extraFooterWikiPage->getParserOutput( $parserOptions ) ) {
+				$html .= $extraFooterWikiPage->getParserOutput( $parserOptions )->mText; 
+			}
 			$html .=  '</div></div>';
 		}
 		$html .= '<div class="container-fluid">

--- a/resources/styles/loop.less
+++ b/resources/styles/loop.less
@@ -443,10 +443,10 @@ footer {
 #extra-footer {
 	background-color: @first-footer-background;
 }
-#extra-footer-content .mw-parser-output p {
+#extra-footer-content p {
 	margin-bottom: 0 !important;
 }
-#extra-footer-content .mw-parser-output img {
+#extra-footer-content img {
 	margin-bottom: 0.5rem;
 }
 

--- a/resources/styles/loop.less
+++ b/resources/styles/loop.less
@@ -357,6 +357,9 @@ code {
 label[for=mw-fr-commentbox] {
 	display: none;
 }
+.fr-diff-patrollink, .patrollink { 
+	display:none; 
+}
 
 /** *** *** *** *** *** *** *** *** *** *** **/
 /** MEDIAWIKI-UI and OO-UI INPUT CHANGES **/


### PR DESCRIPTION
Der zusätzliche Footer wird jetzt aus dem Seiteninhalt der MediaWiki:ExtraFooter Seite generiert. Bitte mit Extension pullen.