### PR TITLE
Score Extension

### DIFF
--- a/resources/styles/less/vendors/ext.Score.less
+++ b/resources/styles/less/vendors/ext.Score.less
@@ -1,0 +1,8 @@
+.mw-ext-score {
+    margin-bottom: 1rem;
+}
+
+.mw-ext-score img {
+    max-width: 100%;
+    height: auto;
+}

--- a/resources/styles/loop.less
+++ b/resources/styles/loop.less
@@ -28,3 +28,4 @@
 @import "less/vendors/ext.FlaggedRevs.less";
 @import "less/vendors/ext.Math.less";
 @import "less/vendors/ext.Plyr.less";
+@import "less/vendors/ext.Score.less";


### PR DESCRIPTION
Adds support for score extension.

- ABC-Notation zur Zeit im PDF nicht unterstützt (sitewise jedoch schon). Möglicherweise sind Absätze beim Parsing das Problem, Lilypond funktioniert wie gewohnt.
Es muss die Score Extension installiert sein: https://github.com/wikimedia/mediawiki-extensions-Score.git