### PR TITLE
Screenreader Optimierungen und anderes

### DIFF
--- a/LoopTemplate.php
+++ b/LoopTemplate.php
@@ -76,7 +76,7 @@ class LoopTemplate extends BaseTemplate {
 									$title = Title::newFromID( $loopStructure->mainPage );
 									echo $this->linkRenderer->makelink(
 										$title,
-										new HtmlArmor( '<h1 class="p-1" id="loop-title">'. $title . '</h1>' )
+										new HtmlArmor( '<header class="h1 p-1" id="loop-title">'. $title . '</header>' )
 									);
 								} elseif ( isset ( $this->data["sidebar"]["navigation"][0]["text"] ) ) {
 									global $wgSitename;
@@ -292,7 +292,7 @@ class LoopTemplate extends BaseTemplate {
 			
 			echo '<div id="usermenu" class="">
 				<div class="dropdown float-right mt-2">
-					<button class="btn btn-light btn-sm dropdown-toggle" type="button" id="user-menu-dropdown" data-toggle="dropdown" aria-haspopup="false" aria-expanded="true">
+					<button class="btn btn-light btn-sm dropdown-toggle" type="button" id="user-menu-dropdown" data-toggle="dropdown" aria-haspopup="false" aria-expanded="true" aria-label="' . $this->getSkin()->msg("loop-toggle-usermenu") . '">
 						<span class="ic ic-personal-urls float-left pr-1 pt-1"></span><span class="d-none d-sm-block float-left">' . $userName . '</span>
 					</button>
 					<div class="dropdown-menu dropdown-menu-right" aria-labelledby="user-menu-dropdown">';
@@ -680,7 +680,7 @@ class LoopTemplate extends BaseTemplate {
 				}
 				
 				$html = '<div class="panel-heading">
-							<h5 class="panel-title mb-0 pl-3 pr-3 pt-2 pb-2">' . $this->getSkin()->msg( 'loop-toc-headline' ) . $editButton .'</h5>
+							<header class="h5 panel-title mb-0 pl-3 pr-3 pt-2 pb-2">' . $this->getSkin()->msg( 'loop-toc-headline' ) . $editButton .'</header>
 						</div>
 						<div id="toc-nav" class="panel-body pr-1 pl-2 pb-2 pl-xl-2 pt-0 toc-tree"><ul>';
 								
@@ -815,7 +815,7 @@ class LoopTemplate extends BaseTemplate {
 				}
 
 				$html = '<div class="panel-heading">
-					<h5 class="panel-title mb-0 pl-3 pr-3 pt-2">' . $this->getSkin()->msg( 'loop-toc-headline' ) .$editButton.'</h5>
+					<header class="h5 panel-title mb-0 pl-3 pr-3 pt-2">' . $this->getSkin()->msg( 'loop-toc-headline' ) .$editButton.'</header>
 					</div>
 					<div id="toc-placeholder" class="panel-body p-1 pb-2 pl-3 pr-3 pt-2">'.$editMsg.'</div>';
 			}
@@ -857,9 +857,9 @@ class LoopTemplate extends BaseTemplate {
 			);
 
 			$wgOut->addModules("skins.loop-plyr.js");
-			$html = '<div class="col-1 mt-1 mb-1 p-0 text-right float-right" id="audio-wrapper" aria-label="'.$this->getSkin()->msg("loop-audiobutton").'" title="'.$this->getSkin()->msg("loop-audiobutton").'">
+			$html = '<div class="col-1 mt-1 mb-1 p-0 text-right float-right" id="audio-wrapper" title="'.$this->getSkin()->msg("loop-audiobutton").'">
 					'.$mp3ExportLink.'
-					<span id="t2s-button" class="ic ic-audio pr-sm-3 mb-1 mt-2 mr-3 float-right"></span>
+					<button id="t2s-button" class="ic ic-audio pr-sm-3 mb-1 mt-2 mr-3 float-right" aria-label="'.$this->getSkin()->msg("loop-audiobutton").'"></button>
 					<audio id="t2s-audio"><source src="" type="audio/mp3"></source></audio>
 				</div>';
 			
@@ -1148,7 +1148,7 @@ class LoopTemplate extends BaseTemplate {
 			$html .= '<span class="page-symbol align-middle ic ic-info pr-0" id="page-info" title="' . $this->data['lastmod']. '"></span>';
 
 		}
-		$html .= '	<span class="page-symbol align-middle ic ic-top cursor-pointer" id="page-topjump" title="'.$this->getSkin()->msg( 'loop-page-icons-jumptotop' ) .'"></span>
+		$html .= '	<button class="page-symbol align-middle ic ic-top cursor-pointer" id="page-topjump" title="'.$this->getSkin()->msg( 'loop-page-icons-jumptotop' ) .'" aria-label="'.$this->getSkin()->msg( 'loop-page-icons-jumptotop' ) .'"></button>
 				</div>';
 		echo $html;
 	}
@@ -1228,7 +1228,7 @@ class LoopTemplate extends BaseTemplate {
 		if ( $user->isAllowedAny( 'loop-export-xml', 'loop-export-pdf', 'loop-export-html', 'loop-export-mp3' ) ) { # TODO other export formats
 			$html = '<div class="panel-wrapper">
 						<div class="panel-heading">
-							<h5 class="panel-title mb-0 pl-3 pr-3 pt-2">' . $this->getSkin()->msg( 'loop-export-headline' ) .'</h5>
+							<header class="h5 panel-title mb-0 pl-3 pr-3 pt-2">' . $this->getSkin()->msg( 'loop-export-headline' ) .'</header>
 						</div>
 						<div id="export-panel" class="panel-body p-1 pb-2 pl-3">
 							<div class="pb-2">';
@@ -1342,7 +1342,7 @@ class LoopTemplate extends BaseTemplate {
 						}
 						if ( $showPanel ) {
 							$html .= '<div class="panel-wrapper custom-panel">';
-							$html .= '<div class="panel-heading mb-2"><h5 class="panel-title mb-0 pl-3 pr-3 pt-2">'.$sidebarHeadline.'</h5></div>';
+							$html .= '<div class="panel-heading mb-2"><header class="h5 panel-title mb-0 pl-3 pr-3 pt-2">'.$sidebarHeadline.'</header></div>';
 							$html .= '<div class="panel-body pl-3 pr-3 pb-3">';
 							$html .= $sidebarContentOutput;
 							$html .= '</div>';
@@ -1500,7 +1500,7 @@ class LoopTemplate extends BaseTemplate {
 			
 			$html = '<div class="panel-wrapper">
 				<div class="panel-heading">
-					<h5 class="panel-title mb-0 pl-3 pr-3 pt-2 pb-2">'.$this->getSkin()->msg("loop-fr-panel-title")->text().'</h5>
+					<header class="h5 panel-title mb-0 pl-3 pr-3 pt-2 pb-2">'.$this->getSkin()->msg("loop-fr-panel-title")->text().'</header>
 				</div>
 				<div class="panel-body pl-3 pr-3 pb-3" id="loop-fr-panel">';
 				

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -26,6 +26,7 @@
 	"loop-page-icons-reportbug": "Fehler melden",
 	"loop-page-edit-menu": "Seitenmenü einblenden",
 	"loop-toggle-sidebar": "Sidebar einblenden",
+	"loop-toggle-usermenu": "Nutzermenü einblenden",
 	"loop-audiobutton": "Seite vorlesen lassen",
 	"imprint": "Impressum",
 	"privacy-policy": "Datenschutz",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -26,6 +26,7 @@
 	"loop-page-icons-reportbug": "Report bug",
 	"loop-page-edit-menu": "Show page dropdown",
 	"loop-toggle-sidebar": "Show sidebar",
+	"loop-toggle-usermenu": "Show user menu",
 	"loop-audiobutton": "Listen to this page",
 	"imprint": "Imprint",
 	"privacy-policy": "Privacy policy",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -26,6 +26,7 @@
 	"loop-page-icons-reportbug": "Tooltip for bug-reporting icon",
 	"loop-page-edit-menu": "Title for edit menu button",
 	"loop-toggle-sidebar": "Title for sidebar button",
+	"loop-toggle-usermenu": "Title for user menu",
 	"loop-audiobutton": "Title for Text2Speech button",
 	"imprint": "Link title for imprint page",
 	"privacy-policy": "Link title for privacy policy page",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -24,6 +24,7 @@
 	"loop-page-icons-reportbug": "Rapportera ett fel",
 	"loop-page-edit-menu": "Visa sidomenyn",
 	"loop-toggle-sidebar": "Visa sidebar",
+	"loop-toggle-usermenu": "Show user menu",
 	"loop-audiobutton": "Lyssna på den här sidan",
 	"imprint": "Imprint",
 	"privacy-policy": "Dataskydd",

--- a/resources/styles/less/components/loopparagraph.less
+++ b/resources/styles/less/components/loopparagraph.less
@@ -8,6 +8,7 @@
     padding: 1rem 0;
     margin-bottom: 1rem;
     display: inline-block;
+    width: 100%;
 }
 
 .loopparagraph_left {

--- a/resources/styles/less/layout/content.less
+++ b/resources/styles/less/layout/content.less
@@ -10,6 +10,12 @@
 	background-color: @content-outter-background;
 }
 
+#page-topjump {
+	background: none;
+    border: none;
+    padding: 0;
+}
+
 #loopsettings-form label {
 	display: inline;
 }

--- a/resources/styles/less/layout/general.less
+++ b/resources/styles/less/layout/general.less
@@ -11,8 +11,7 @@
 	margin-bottom: 15px;
 }
 
-
- a.icon-link:hover {
+a.icon-link:hover {
 	text-decoration: none !important;
 }
 .accent-color {

--- a/resources/styles/less/layout/header.less
+++ b/resources/styles/less/layout/header.less
@@ -9,7 +9,9 @@
 	text-decoration: none !important;
 	padding-top: 20px;
 }
-h1#loop-title, h1#loop-title:hover {
+header#loop-title, header#loop-title:hover {
+	display: block;
+	font-size: 2em;
 	color: @loop-title-color;
 	padding-top: @title-padding !important;
 }
@@ -21,7 +23,7 @@ h1#loop-title, h1#loop-title:hover {
 	background-image: url(@logo-url);
 	background-repeat: no-repeat;
 	height: 42px;
-	width: auto;	
+	width: auto;
 	background-size: auto 100%;
 	background-position: 0 center;
 }
@@ -75,10 +77,10 @@ ol.breadcrumb {
 	cursor: pointer;
 	width: 16px;
 	color: @icon-color;
-}
-
-#t2s-button {
+	border: none;
+    background: none;
 	display: block;
+	padding: 0;
 }
 
 @keyframes rotating {

--- a/resources/styles/less/vendors/ext.Quiz.less
+++ b/resources/styles/less/vendors/ext.Quiz.less
@@ -32,6 +32,7 @@
 
 .quiz th {
     padding: 0 15px 5px 0;
+    white-space: nowrap;
 }
 
 .quiz .quizQuestions p {

--- a/resources/styles/less/vendors/ext.WikiEditor.less
+++ b/resources/styles/less/vendors/ext.WikiEditor.less
@@ -1,6 +1,9 @@
 /** *** ** *** **/
 /** WIKIEDITOR **/
 /** *** ** *** **/
+.wikiEditor-ui {
+	margin-bottom: 1rem;
+}
 #wikiEditor-section-references .pages div div span { /* elements in 'booklet'-type content of references tab */
 	min-width: 95%;
 	font-family: inherit;


### PR DESCRIPTION
Einige Tests unter anderem mit NVDA Screenreader durchgeführt.

- JumpToTop-Icon ist nun `<button>` damit Screenreader diesen erkennt.
- Nutzermenü hat aria-label erhalten. **ToDo**: Schwedische Übersetzung
- Einige `<h5>` wurden zum HTML5 `<header>` aus Semantikgründen (Analyseplugins interpretierten die Sidebar-`<h5>`s als Teil des Contents.
- 100% Breite eines Zitates in Mobile gefixt
- WikiEditor hat nun 1rem Abstand nach unten
- t2s-Button (Seite vorlesen) nun auch Button für den Screenreader
- Teilweise Umpositionierungen der aria-labels in höhere HTML-Hierarchie, damit Screenreader diese ansprechen kann
