### PR TITLE
Fixes Part 2

### DIFF
--- a/Loop.skin.php
+++ b/Loop.skin.php
@@ -18,7 +18,7 @@ class SkinLoop extends SkinTemplate {
 		global $wgStylePath, $wgFavicon;
 		$wgFavicon = "$wgStylePath/Loop/resources/img/favicon.ico";
 		
-		$out->addHeadItem('meta_ie_edge', '<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">');
+		$out->addHeadItem('meta_ie_edge', '<meta http-equiv="X-UA-Compatible" content="IE=edge">');
 		$out->addMeta( 'viewport', 'width=device-width, initial-scale=1.0' );
 		
 		$out->addModuleStyles( array(

--- a/LoopTemplate.php
+++ b/LoopTemplate.php
@@ -33,7 +33,7 @@ class LoopTemplate extends BaseTemplate {
 		
 		if( $this->renderMode != "epub" ) { ?>
 		<div id="page-wrapper">
-			<section>
+			<header>
 				<div class="container p-0" id="banner-wrapper">
 					<div class="container p-0" id="banner-container">
 						<div class="w-100" id="banner-logo-container">
@@ -143,7 +143,7 @@ class LoopTemplate extends BaseTemplate {
 					</div>
 				</div>
 				</div>
-			</section>
+			</header>
 			
 			<!--BREADCRUMB SECTION -->
 			<section>
@@ -169,7 +169,7 @@ class LoopTemplate extends BaseTemplate {
 						</div> <!--End of row-->
 					</div> <!--End of container-->
 				</div>
-				<div class="container" id="breadcrumb-container">
+				<nav class="container" id="breadcrumb-container">
 					<div class="row">
 						<div class="col-12 col-sm-12 col-md-12 col-lg-9 col-xl-9 p-0" id="breadcrumb-wrapper">
 							<div class="col-11 mt-2 mb-2 mt-md-2 mb-md-2 pl-2 pr-2 pr-sm-0 float-left" id="breadcrumb-area">
@@ -181,7 +181,7 @@ class LoopTemplate extends BaseTemplate {
 							}?>
 						</div>
 					</div> <!--End of row-->
-				</div> 
+				</nav> 
 			</section> <!--End of Breadcrumb section-->
 			
 			<!-- CONTENT SECTION -->
@@ -349,7 +349,7 @@ class LoopTemplate extends BaseTemplate {
 				</div>';
 			} elseif ( isset ( $personTools ['login'] ) ) {
 				echo '<div class="float-right mt-2">
-				<a id="login-button" href="' . $personTools ['login'] ['links'] [0] ['href'] . '" alt="'.$personTools ['login'] ['links'] [0] ['text'].'">
+				<a id="login-button" href="' . $personTools ['login'] ['links'] [0] ['href'] . '">
 				<button class="btn btn-light btn-sm" type="button" id="user-menu-dropdown" aria-haspopup="true" aria-expanded="true">
 				<span class="ic ic-personal-urls float-left pr-md-1 pt-1"></span><span class="d-none d-sm-block float-left">';
 
@@ -892,7 +892,7 @@ class LoopTemplate extends BaseTemplate {
 		unset($this->data['content_navigation']['namespaces']); # removes talk pages from menu
 
 		echo '<div class="dropdown float-right" id="admin-dropdown">
-			<button  id="admin-btn" class="btn btn-light dropdown-toggle page-nav-btn" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="'.$this->getSkin()->msg("loop-page-edit-menu").'" title="'.$this->getSkin()->msg("loop-page-edit-menu").'">
+			<button class="btn btn-light dropdown-toggle page-nav-btn" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="'.$this->getSkin()->msg("loop-page-edit-menu").'" title="'.$this->getSkin()->msg("loop-page-edit-menu").'">
 				<span class="ic ic-preferences"></span>
 			</button>
 			<div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">';

--- a/LoopTemplate.php
+++ b/LoopTemplate.php
@@ -97,7 +97,7 @@ class LoopTemplate extends BaseTemplate {
 										<?php $this->outputNavigation( $loopStructure ); 
 											echo '<div class="btn-group float-right">'; 
 											if( $this->renderMode != "offline" && $this->user->isAllowed( 'read' ) ) { 
-												echo '<button type="button" id="toggle-mobile-search-btn" class="btn btn-light page-nav-btn d-md-none" aria-label=""><span class="ic ic-search"></span></button>';
+												echo '<button type="button" id="toggle-mobile-search-btn" class="btn btn-light page-nav-btn d-md-none" ><span class="ic ic-search"></span></button>';
 												$this->outputPageEditMenu( );
 											}
 											if ( isset( $loopStructure->mainPage ) && $this->user->isAllowed('read') ) {?>
@@ -371,7 +371,7 @@ class LoopTemplate extends BaseTemplate {
 		$lsi = LoopStructureItem::newFromIds( $article_id );
 			
 		$disabled = ( isset ( $this->data["sidebar"]["navigation"][0]["text"] ) || $mainPage ) ? "" : "disabled";
-		$home_button = '<button type="button" class="btn btn-light page-nav-btn" '.$disabled.' aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-home' ).'"><span class="ic ic-home"></span></button>';
+		$home_button = '<button type="button" class="btn btn-light page-nav-btn" tabindex="-1" '.$disabled.' aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-home' ).'"><span class="ic ic-home"></span></button>';
 		
 		if ( $mainPage ) {
 			echo $this->linkRenderer->makelink(
@@ -396,7 +396,7 @@ class LoopTemplate extends BaseTemplate {
 		if ( $lsi ) {
 			$previousChapterItem = $lsi->getPreviousChapterItem();
 		}
-		$previous_chapter_button = '<button type="button" class="btn btn-light page-nav-btn" aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-previous-chapter' ).'" ';
+		$previous_chapter_button = '<button type="button" class="btn btn-light page-nav-btn" tabindex="-1" aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-previous-chapter' ).'" ';
 			
 		if ( ! isset( $previousChapterItem->article ) || ! $user->isAllowed('read') ) {
 			$previous_chapter_button .= 'disabled="disabled"';
@@ -428,7 +428,7 @@ class LoopTemplate extends BaseTemplate {
 			$previousPageItem = LoopStructureItem::newFromIds($previousPage);
 		}
 		
-		$previous_page_button = '<button type="button" class="btn btn-light page-nav-btn" aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-previous-page' ).'" ';
+		$previous_page_button = '<button type="button" class="btn btn-light page-nav-btn" tabindex="-1" aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-previous-page' ).'" ';
 		
 		if ( ! isset( $previousPage ) || $previousPage == 0 || ! $user->isAllowed('read') ) {
 			$previous_page_button .= 'disabled="disabled"';
@@ -456,7 +456,7 @@ class LoopTemplate extends BaseTemplate {
 		
 		
 		// TOC  button
-		$toc_button = '<button type="button" class="btn btn-light page-nav-btn" title="'. $this->getSkin()->msg('loop-navigation-label-toc'). '" aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-toc' ).'"';
+		$toc_button = '<button type="button" class="btn btn-light page-nav-btn" tabindex="-1" title="'. $this->getSkin()->msg('loop-navigation-label-toc'). '" aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-toc' ).'"';
 		
 		if ( ! $user->isAllowed('read') ) {
 			$toc_button .= 'disabled="disabled"';
@@ -483,7 +483,7 @@ class LoopTemplate extends BaseTemplate {
 			$nextPage = $lsi->nextArticle;
 			$nextPageItem = LoopStructureItem::newFromIds($nextPage);
 		}
-		$next_page_button = '<button type="button" class="btn btn-light page-nav-btn" aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-next-page' ).'" ';
+		$next_page_button = '<button type="button" class="btn btn-light page-nav-btn" tabindex="-1" aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-next-page' ).'" ';
 		
 		if ( ! isset( $nextPage ) || $nextPage == 0 || ! $user->isAllowed('read') ) {
 			$next_page_button .= 'disabled="disabled"';
@@ -514,7 +514,7 @@ class LoopTemplate extends BaseTemplate {
 		if ( $lsi ) {
 		 $nextChapterItem = $lsi->getNextChapterItem();
 		}
-		$next_chapter_button = '<button type="button" class="btn btn-light page-nav-btn" aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-next-chapter' ).'" ';
+		$next_chapter_button = '<button type="button" class="btn btn-light page-nav-btn" tabindex="-1" aria-label="'.$this->getSkin()->msg( 'loop-navigation-label-next-chapter' ).'" ';
 			
 		if ( ! isset( $nextChapterItem->article ) || ! $user->isAllowed('read') ) {
 			$next_chapter_button .= 'disabled="disabled"';

--- a/resources/js/loop.js
+++ b/resources/js/loop.js
@@ -5,6 +5,8 @@ $( document ).ready( function () {
 	var navMenu = $( '#sidebar-wrapper' ); 
 	var mobileSearchBtn = $( '#toggle-mobile-search-btn' );
 	var mobileSearchBar = $( '#mobile-searchbar' );
+	var pageNavBtn = $( '#dropdownMenuButton' );
+	var userNavBtn = $( '#user-menu-dropdown' );
 	var tocNav = $('#toc-nav');
 	var tocSpecialNav = $('#toc-specialpages');
 	
@@ -16,8 +18,36 @@ $( document ).ready( function () {
 	$('footer').animate({"opacity": "1"}, 200);
 	
 	/**
+	 * Accessibility workaround for page menu.
+	 * Simulates states to make the tab key trigger working on buttons
+	*/
+	pageNavBtn.add(userNavBtn).keydown(function(e) {
+		if (e.keyCode === 9) { //tab key
+			if(!$(this).parent( '.dropdown' ).hasClass( 'show' )) {
+				//.tab('show') not working as intended so manually:
+				$(this).next( '.dropdown-menu' ).addClass( 'show' );
+				$(this).parent( '.dropdown' ).addClass( 'show' );
+				$(this).attr( 'aria-expanded' , 'true' );
+			} else {
+				$(this).next( '.dropdown-menu').removeClass( 'show' );
+				$(this).parent( '.dropdown').removeClass( 'show' );
+				$(this).attr( 'aria-expanded', 'false' );
+			}
+		}
+	});
+	// if focus is lost after last item
+	pageNavBtn.add(userNavBtn).next( '.dropdown-menu' ).children().last().focusout( function () {
+		$(this).parent( '.dropdown-menu').removeClass( 'show' );
+		$(this).parent( '.dropdown' ).removeClass( 'show' );
+		$(this).attr( 'aria-expanded', 'false' );
+	});
+
+	/**
 	 * Toggle visibility of mobile toc menu.
 	 */
+
+	 // user-menu-dropdown
+
 	mobileNavBtn.click( function () {
 		navMenu.toggleClass( 'mobile-sidebar' );
 	    navMenu.toggleClass( 'd-none' );

--- a/resources/styles/less/vendors/ext.Bootstrap.less
+++ b/resources/styles/less/vendors/ext.Bootstrap.less
@@ -12,6 +12,7 @@
 	box-shadow:none !important;
 	outline:0px !important;
 }
+
 .page-nav-btn{
 	border-radius: 2px;
 	padding: 0;


### PR DESCRIPTION
- chrome=1 aus meta entfernt aufgrund w3-Validator: https://www.mediaevent.de/meta/
- Entfernung alt-Tag Login-Button (da kein Bild)
- `<section>` -> `<header>` aufgrund Semantik
- LoopParagraph erhält `<blockquote>`
- Breadcrumb ist nun `<nav>`
- Seitenmenü kann nun ebenfalls wie User-Menü geschlossen werden indem irgendeine freie Fläche geklickt wird
- Seitenmenü nun per Tab-Selektion durchwählbar. 
- Tabindex der Navigation gefixt. Durchwechseln per Tab nun ohne doppeltes Klicken möglich
- Sidenote-Container nun `<div>`
- **Work in Progress**: Per Tab Key durchwechselbare Button-Dropdowns für Barrierearmheit. Einzelne Spezialfälle müssen noch abgefangen werden.