### PR TITLE
Fix breadcrumb + Legacy Page Numbering

### DIFF
--- a/LoopTemplate.php
+++ b/LoopTemplate.php
@@ -13,8 +13,8 @@ class LoopTemplate extends BaseTemplate {
 	
 	public function execute() {
 		
-		global $wgDefaultUserOptions, $wgOut;
-		 
+		global $wgDefaultUserOptions, $wgOut, $wgLoopPageNumbering;
+		
 		$loopStructure = new LoopStructure();
 		$loopStructure->loadStructureItems();
 		$this->linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
@@ -196,7 +196,8 @@ class LoopTemplate extends BaseTemplate {
 	           							<?php 
 										} // end of excluding rendermode-epub 
 										
-										global $wgLoopLegacyShowTitles;
+										global $wgLoopLegacyShowTitles, $wgLoopPageNumbering;
+										
 										if ( $wgLoopLegacyShowTitles ) {
 											
 											if ( isset( $loopStructure->mainPage ) ) {
@@ -204,8 +205,16 @@ class LoopTemplate extends BaseTemplate {
 												$article_id = $this->title->getArticleID();
 												$lsi = LoopStructureItem::newFromIds($article_id); 
 												
+												
+
 												if ( $lsi ) {
-													$displayTitle = $lsi->tocNumber.' '.$lsi->tocText;
+													if( $wgLoopPageNumbering ) {
+														$pageNumber = $lsi->tocNumber;
+													} else {
+														$pageNumber = '';
+													}
+
+													$displayTitle = $pageNumber.' '.$lsi->tocText;
 												} else {
 													$displayTitle = $this->title->mTextform;
 												}
@@ -630,7 +639,7 @@ class LoopTemplate extends BaseTemplate {
 	
 	private function outputToc( $loopStructure ) {
 			
-		global $wgDefaultUserOptions; 
+		global $wgDefaultUserOptions, $wgLoopPageNumbering; 
 		
 		$article_id = $this->title->getArticleID();
 		$lsi = LoopStructureItem::newFromIds( $article_id );
@@ -732,7 +741,6 @@ class LoopTemplate extends BaseTemplate {
 					if( ! $rootNode ) {
 						
 						// outputs the first node (mainpage)
-						
 						$html .= '<li class="toc-main mb-1">' .
 							$this->linkRenderer->makelink(
 								$tmpTitle,
@@ -787,12 +795,18 @@ class LoopTemplate extends BaseTemplate {
 					
 					// outputs the page in a tree
 					
+					if($wgLoopPageNumbering) {
+						$pageNumbering = '<span class="tocnumber '. $activeClass .'">'.$tmpChapter.'</span>';
+					} else {
+						$pageNumbering = '';
+					}
+
 					$html .= '<li'.$nodeData.'  data-toc-level="'.$tmpTocLevel.'">' . $caret .
 					
 						$this->linkRenderer->makelink(
 							$tmpTitle,
 							new HtmlArmor( 
-								'<span class="tocnumber '. $activeClass .'">'.$tmpChapter.'</span>
+								$pageNumbering . '
 								<span class="toctext '. $activeClass .'">'.$tmpText  .'</span>' ),
 							array(
 								'class' => 'aToc ml-1',

--- a/LoopTemplate.php
+++ b/LoopTemplate.php
@@ -208,7 +208,7 @@ class LoopTemplate extends BaseTemplate {
 												
 
 												if ( $lsi ) {
-													if( $wgLegacyPageNumbering ) {
+													if ( $wgLegacyPageNumbering ) {
 														$pageNumber = $lsi->tocNumber;
 													} else {
 														$pageNumber = '';

--- a/LoopTemplate.php
+++ b/LoopTemplate.php
@@ -13,7 +13,7 @@ class LoopTemplate extends BaseTemplate {
 	
 	public function execute() {
 		
-		global $wgDefaultUserOptions, $wgOut, $wgLoopPageNumbering;
+		global $wgDefaultUserOptions, $wgOut, $wgLegacyPageNumbering;
 		
 		$loopStructure = new LoopStructure();
 		$loopStructure->loadStructureItems();
@@ -196,7 +196,7 @@ class LoopTemplate extends BaseTemplate {
 	           							<?php 
 										} // end of excluding rendermode-epub 
 										
-										global $wgLoopLegacyShowTitles, $wgLoopPageNumbering;
+										global $wgLoopLegacyShowTitles, $wgLegacyPageNumbering;
 										
 										if ( $wgLoopLegacyShowTitles ) {
 											
@@ -208,7 +208,7 @@ class LoopTemplate extends BaseTemplate {
 												
 
 												if ( $lsi ) {
-													if( $wgLoopPageNumbering ) {
+													if( $wgLegacyPageNumbering ) {
 														$pageNumber = $lsi->tocNumber;
 													} else {
 														$pageNumber = '';
@@ -639,7 +639,7 @@ class LoopTemplate extends BaseTemplate {
 	
 	private function outputToc( $loopStructure ) {
 			
-		global $wgDefaultUserOptions, $wgLoopPageNumbering; 
+		global $wgDefaultUserOptions, $wgLegacyPageNumbering; 
 		
 		$article_id = $this->title->getArticleID();
 		$lsi = LoopStructureItem::newFromIds( $article_id );
@@ -795,7 +795,7 @@ class LoopTemplate extends BaseTemplate {
 					
 					// outputs the page in a tree
 					
-					if($wgLoopPageNumbering) {
+					if($wgLegacyPageNumbering) {
 						$pageNumbering = '<span class="tocnumber '. $activeClass .'">'.$tmpChapter.'</span>';
 					} else {
 						$pageNumbering = '';

--- a/resources/styles/less/base/mediawiki.less
+++ b/resources/styles/less/base/mediawiki.less
@@ -22,10 +22,6 @@ body {
 	margin: 0 !important;
 }
 
-.wikitable {
-	
-}
-
 .image img, .fullImageLink a img, .thumb, .thumbinner, .responsive-image, .responsive-video, .noresize {
 	max-width: 100% !important;
 	height: auto !important;
@@ -159,4 +155,8 @@ code {
 	background-color: darken(@mw-ui-highlighted-button-bg, 5%);
 	border-color: darken(@mw-ui-highlighted-button-bg, 5%);
 	box-shadow: inset 0 0 0 1px darken(@mw-ui-highlighted-button-bg, 5%);
+}
+
+.oo-ui-textInputWidget input {
+	height: inherit;
 }


### PR DESCRIPTION
- Home Seite ist aus Breadcrumb entfernt
- $wgLegacyPageNumbering = false; blendet "Toc-Numbers" aus.
  - PDF (Inhaltsverzeichnis, Headertitle links + rechts, LoopToc-Element)
  - Page (Inhaltsverzeichnis, Sidebar-Toc, LoopToc-Element, Breadcrumbs)
- .oo-ui-textInputWidget input Fix da 1px zu hoch