### PR TITLE
Fix images + small fixes

### DIFF
--- a/resources/styles/less/base/mediawiki.less
+++ b/resources/styles/less/base/mediawiki.less
@@ -79,6 +79,25 @@ code {
 	margin: 0 0 1rem 1rem;
 }
 
+.thumb {
+	margin-bottom: 1rem;
+}
+
+// right align
+.thumb.tright {
+	margin-left: 1rem
+}
+
+// left align
+.thumb.tleft {
+	margin-right: 1rem
+}
+
+// center align
+.center .thumb .thumbinner {
+ margin: 0 auto;
+}
+
 /* #mw-content-text :last-child > * {
 	 margin-bottom: 0 !important;
 } */

--- a/resources/styles/less/components/loopobject.less
+++ b/resources/styles/less/components/loopobject.less
@@ -67,3 +67,11 @@
 .looparea-task .loop_task .loop_object_footer .loop_object_icon {
 	display: none;
 } 
+
+.loop_object.tright {
+	margin: 0 0 1rem 1rem;
+}
+
+.loop_object.tleft {
+	margin: 0 1rem 1rem 0;
+}

--- a/resources/styles/less/components/loopobject.less
+++ b/resources/styles/less/components/loopobject.less
@@ -75,3 +75,9 @@
 .loop_object.tleft {
 	margin: 0 1rem 1rem 0;
 }
+
+@media (max-width: 576px) {
+	.loop_object {
+		width: 100%;
+	}
+}

--- a/resources/styles/less/components/loopzoom.less
+++ b/resources/styles/less/components/loopzoom.less
@@ -64,9 +64,9 @@
     margin: 0 auto;
 }
 
-.loopzoom-modal {
-    //padding-left: 17px;
-   // padding: 0 20px;
+.loopzoom-modal .noresize div:first-of-type,
+.loopzoom .noresize div:first-of-type {
+    display: none !important;
 }
 
 .loopzoom-modal .modal-header {
@@ -75,6 +75,7 @@
 }
 
 .loopzoom-modal .modal-content {
+    background: #fff;
     border: none;
     border-radius: 0;
     padding: 8px;


### PR DESCRIPTION
- Deutsche Werte (rechts|links statt left|right) machen in Bilderausrichtung kein Problem mehr
- Bilder-Ausrichtung funktioniert auf Site (siehe Startseite von Oldenburg; PDF funktioniert noch nicht diesbezüglich. Pull Request enthält den aktuellen Stand)
- Modal hat nun rechts keinen fehlenden 1px-Rand
- Anpassungen/Fix der Listen auf Site + PDF (ToDo niedrige Prio: Listen im PDF nach einigen Verschachtelungen fixen)
- Minor Fixes