### PR TITLE
Fixes und Align

### DIFF
--- a/resources/styles/less/base/mediawiki.less
+++ b/resources/styles/less/base/mediawiki.less
@@ -80,6 +80,30 @@ code {
 	margin: 0 0 1rem 1rem;
 }
 
+.thumb.tright .thumbinner {
+	margin: 0 0 1rem 1rem;
+}
+
+.thumb.tleft .thumbinner {
+	margin: 0 1rem 1rem 0;
+}
+
+.thumb.tnone .thumbinner {
+	margin: 0 0 1rem 0;
+}
+
+.center .thumb.tnone .thumbinner {
+	margin: 0 auto;
+	margin-bottom: 1rem;
+}
+
+@media (max-width: 576px) {
+	.thumb.tleft .thumbinner,
+	.thumb.tright .thumbinner {
+		margin: 0 0 1rem 0;
+	}
+}
+
 /* #mw-content-text :last-child > * {
 	 margin-bottom: 0 !important;
 } */

--- a/resources/styles/less/base/mediawiki.less
+++ b/resources/styles/less/base/mediawiki.less
@@ -104,6 +104,16 @@ code {
 	}
 }
 
+.warningbox p {
+	margin-bottom: 0;
+}
+
+// frame
+
+.framed {
+	border: 1px solid lighten( @bluegray, 20%);
+}
+
 /* #mw-content-text :last-child > * {
 	 margin-bottom: 0 !important;
 } */

--- a/resources/styles/less/components/loopobject.less
+++ b/resources/styles/less/components/loopobject.less
@@ -12,21 +12,16 @@
 }
 
 .loop_object_content {
-	margin-bottom:5px;
+	//margin-bottom:5px;
+	display: inline-block;
 }
 
-.loop_object.tright {
-	margin: 0 0 1rem 1rem;
+.loop_object.float-right {
+	margin-left: 1rem;
 }
 
-.loop_object.tleft {
-	margin: 0 1rem 1rem 0;
-}
-
-@media (max-width: 576px) {
-	.loop_object {
-		width: 100%;
-	}
+.loop_object.float-left {
+	margin-right: 1rem;
 }
 
 .loop_object_content .float-left, .loop_object_content .float-right {
@@ -72,4 +67,22 @@
 
 .looparea-task .loop_task .loop_object_footer .loop_object_icon {
 	display: none;
-} 
+}
+
+@media (max-width: 576px) {
+	// .loop_object.tright,
+	// .loop_object.tleft {
+	// 	float: none;
+	// }
+
+	.loop_object {
+		width: 100%;
+		float: none;
+		display: grid;
+	}
+
+	.loop_object .thumb  {
+		float: left;
+	}
+
+}

--- a/resources/styles/less/components/loopobject.less
+++ b/resources/styles/less/components/loopobject.less
@@ -24,11 +24,13 @@
 	margin-right: 1rem;
 }
 
-.loop_object_content .float-left, .loop_object_content .float-right {
+.loop_object_content .float-left,
+.loop_object_content .float-right {
 	float:none;
 }
 
-.loop_object_name, .loop_object_number, .loop_object_title_seperator {
+.loop_object_name, .loop_object_number,
+.loop_object_title_seperator {
 	font-weight:bold;
 }
 
@@ -70,10 +72,6 @@
 }
 
 @media (max-width: 576px) {
-	// .loop_object.tright,
-	// .loop_object.tleft {
-	// 	float: none;
-	// }
 
 	.loop_object {
 		width: 100%;

--- a/resources/styles/less/pages/history.less
+++ b/resources/styles/less/pages/history.less
@@ -1,0 +1,11 @@
+.action-history .historysubmit {
+    margin: 1rem 0;
+}
+
+#pagehistory li {
+    margin-bottom: .5rem;
+}
+
+#pagehistory input[type="radio"]:nth-child(2) {
+    margin: 0 10px;
+}

--- a/resources/styles/loop.less
+++ b/resources/styles/loop.less
@@ -13,6 +13,7 @@
 /* Pages */
 @import "less/pages/specialpages.less";
 @import "less/pages/structure.less";
+@import 'less/pages/history.less';
 
 /* Components */
 @import "less/components/looparea.less";


### PR DESCRIPTION
- Versionsgeschichte-Page hat etwas mehr Abstände
- Aligns der Bilder mit oder ohne loop_object funktioniert nun (siehe Oldenburgs Startseite)
- mobile fixes
- Accordion-Title im PDF bold