### PR TITLE
Inline Spoiler Fix

### DIFF
--- a/resources/styles/less/components/loopspoiler.less
+++ b/resources/styles/less/components/loopspoiler.less
@@ -45,7 +45,13 @@
 }
 
 .btn.loopspoiler_type_default {
-	padding: 0px 5px;
+    padding: 0px 5px;
+    border-top: 0;
+    border-bottom: 0;
+    line-height: 1.3rem;
+    font-size: .7rem;
+    text-transform: uppercase;
+    letter-spacing: .05rem;
 }
 
 .btn.spoileractive {
@@ -80,7 +86,6 @@
     margin-top: -2px;
     margin-right: .75rem;
     box-shadow: 0 2px 7px 0px rgba(63, 84, 130, 0.5);
-    z-index: 1000;
 }
 
 .loopspoiler_transparent_content {
@@ -89,7 +94,6 @@
     padding: .75rem;
     margin-top: -2px;
     margin-right: .75rem;
-    z-index: 1000;
 }
 
 /* if loop area is inside loop spoiler*/
@@ -98,9 +102,6 @@
     width: 100%;
 }
 
-.loopspoiler .mwe-math-element, .loopspoiler .mw-empty-elt {
-    display: none;
-}
 @media(max-width: 991px) {
     .loopspoiler_content_wrapper .looparea {
         margin: 0 1rem;


### PR DESCRIPTION
Auf Oldenburg einsehbar.

- Inline-Spoiler werden besser dargestellt (greifen nicht in den Zeilenabstand ein)