### PR TITLE
fix icon size for custom icons in loop areas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
 	"require": {
-		"twbs/bootstrap":	"4.1.1"
+		"twbs/bootstrap":	"^4.0"
 	}
 }

--- a/resources/styles/less/components/looparea.less
+++ b/resources/styles/less/components/looparea.less
@@ -36,8 +36,8 @@
 }
 
 .looparea .ownicon {
-    width: 4rem;
-    height: 4rem;
+    width: 2rem;
+    height: 2rem;
     background-size: contain;
     background-repeat: no-repeat;
     margin: 0 auto;


### PR DESCRIPTION
Höhe und breite von .looparea .ownicon wird von 4rem auf 2rem reduziert -> loop icons und custom icons werden in gleicher Größe dargestellt (32x32)
Issue: [Loop-42](https://oncampus-gmbh.atlassian.net/browse/LOOP-42)