### PR TITLE
Fixed Max Length

### DIFF
--- a/resources/styles/less/components/loopaccordion.less
+++ b/resources/styles/less/components/loopaccordion.less
@@ -23,7 +23,7 @@
     -webkit-box-sizing: border-box;
 }
 .accordion-row input:checked ~ .accordion-content { 
-    max-height: 100em;
+    max-height: 100%;
 }
 .accordion-row input[type=checkbox] + label::before { 
     content: "\23F5";


### PR DESCRIPTION
As requested by [this ticket](https://oncampus-gmbh.atlassian.net/browse/LOOP-60?atlOrigin=eyJpIjoiYTczMGFmNjgwYTljNDZjYzk4NzQzMGJkYTYyN2IzNTYiLCJwIjoiaiJ9) the max length on the accordion is now fixed as to display any amount of content and not cut anything inside